### PR TITLE
Add issue templates, security policy, and contributing guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Report a bug in A2UI Blazor
+title: ''
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear description of what the bug is.
+
+**To reproduce**
+Steps to reproduce:
+1. ...
+2. ...
+
+**Expected behavior**
+What you expected to happen.
+
+**Environment**
+- .NET version:
+- Blazor hosting model: [WASM / Server]
+- Browser:
+- A2UI.Blazor version:
+
+**Additional context**
+Any other context, screenshots, or error messages.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+**What problem does this solve?**
+A clear description of the problem or use case.
+
+**Proposed solution**
+How you'd like it to work.
+
+**Alternatives considered**
+Other approaches you've thought about.
+
+**Additional context**
+Any other context, mockups, or references.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing to A2UI Blazor
+
+Thanks for your interest in contributing! Here's how to get started.
+
+## Getting Started
+
+1. Fork the repository
+2. Clone your fork and create a branch: `git checkout -b dev/your-feature`
+3. Make your changes
+4. Run the tests: `dotnet test`
+5. Push and open a pull request against `main`
+
+## Development Setup
+
+### Prerequisites
+
+- [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
+- [uv](https://docs.astral.sh/uv/) + Python 3.10+ (for the Python server sample)
+- [Playwright browsers](https://playwright.dev/dotnet/docs/intro#installing-playwright): `pwsh tests/A2UI.Blazor.Playwright/bin/Debug/net8.0/playwright.ps1 install`
+
+### Build and Test
+
+```bash
+dotnet build
+dotnet test tests/A2UI.Blazor.Tests          # 115 bUnit component tests
+dotnet test tests/A2UI.Blazor.Playwright     # 19 Playwright E2E tests
+```
+
+Playwright tests start their own servers on ports 15050/15200 and won't interfere with any manually-started dev servers.
+
+## Branch Conventions
+
+- `main` — protected, requires PR with review
+- `dev/*` — feature and fix branches
+
+## Pull Requests
+
+- Keep PRs focused — one feature or fix per PR
+- Include tests for new functionality
+- Update the README or ROADMAP if your change affects the public API or project direction
+- PRs are squash-merged; write a clear title and description
+
+## What to Work On
+
+Check the [Roadmap](ROADMAP.md) for planned work. Items in v0.2.0 and v0.3.0 are good candidates. Open an issue first to discuss your approach for larger changes.
+
+## Code Style
+
+- Follow existing patterns in the codebase
+- No third-party dependencies in the core library (`A2UI.Blazor`)
+- Prefix CSS classes with `a2ui-`
+- XML doc comments on public APIs

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| 0.x (latest pre-release) | Yes |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it responsibly:
+
+1. **Do not** open a public issue.
+2. Email the maintainers or use [GitHub's private vulnerability reporting](https://github.com/23min/a2ui-blazor/security/advisories/new).
+3. Include a description of the vulnerability, steps to reproduce, and potential impact.
+
+We will acknowledge receipt within 48 hours and aim to release a fix within 7 days for critical issues.
+
+## Security Model
+
+A2UI Blazor follows the A2UI protocol's security model:
+
+- **No executable code from agents** — agents send declarative component trees, never JavaScript or executable code.
+- **Pre-approved component catalog** — only registered component types are rendered. Unknown types are ignored.
+- **Data binding is read-only** — components read from the data model but cannot modify it directly.
+- **Actions are explicit** — user interactions are sent to the server as structured action objects, not arbitrary data.


### PR DESCRIPTION
## Summary
- Bug report and feature request issue templates in `.github/ISSUE_TEMPLATE/`
- `SECURITY.md` with vulnerability reporting process and A2UI security model
- `CONTRIBUTING.md` with dev setup, branch conventions, and PR guidelines

## Also configured (via API, not in this PR)
- Homepage URL set to https://a2ui.org
- Added topics: dotnet, csharp, nuget, ai-agents, agent-ui, streaming, blazor-server
- Wiki disabled (docs live in the repo)
- Delete branch on merge enabled
- Branch protection on main: PRs required, 1 review required

## Test plan
- [x] Verify issue templates appear when creating a new issue on GitHub
- [x] Verify SECURITY.md shows in the Security tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)