### PR TITLE
Add spec compliance tracking and project conventions

### DIFF
--- a/.github/ISSUE_TEMPLATE/spec-compliance.md
+++ b/.github/ISSUE_TEMPLATE/spec-compliance.md
@@ -1,0 +1,29 @@
+---
+name: Spec compliance
+about: Track A2UI specification compliance gaps
+title: ''
+labels: spec-compliance
+assignees: ''
+---
+
+**Spec reference**
+Link to the relevant section of the A2UI specification.
+
+**Current behavior**
+What we currently do (or don't do).
+
+**Required behavior**
+What the spec requires.
+
+**Affected files**
+Key files that need changes.
+
+**SPECIFICATION.md reference**
+Which row(s) in SPECIFICATION.md this addresses.
+
+**Acceptance criteria**
+- [ ] Implementation matches spec
+- [ ] Tests added (red-green-refactor)
+- [ ] SPECIFICATION.md updated (gap → compliant)
+- [ ] Sample servers updated if affected (parity)
+- [ ] Sample apps updated if affected (parity)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,89 @@
+# CLAUDE.md
+
+## Project
+
+A2UI Blazor — an A2UI protocol renderer for Blazor (WebAssembly and Server). Implements the [A2UI v0.9 specification](https://github.com/google/A2UI/tree/main/specification/v0_9).
+
+## Quick Reference
+
+```bash
+dotnet build                    # Build entire solution
+dotnet test                     # Run all tests (must pass before committing)
+dotnet build samples/dotnet-server   # Build .NET server only
+dotnet build samples/blazor-wasm-spa # Build WASM client only
+```
+
+## Solution Structure
+
+```
+src/A2UI.Blazor            # Core library — renderer, components, services
+src/A2UI.Blazor.Server     # Server-side helpers for ASP.NET Core agents
+samples/blazor-wasm-spa    # Blazor WebAssembly client sample
+samples/blazor-server-app  # Blazor Server client sample
+samples/dotnet-server      # .NET A2UI agent server sample
+samples/python-server      # Python A2UI agent server sample
+tests/A2UI.Blazor.Tests    # Unit + component tests (xUnit + bUnit)
+tests/A2UI.Blazor.Playwright  # E2E tests (Playwright + NUnit)
+```
+
+## Rules
+
+### Development Approach: Red-Green-Refactor
+
+Follow the RED-GREEN-REFACTOR cycle for all code changes:
+
+1. **RED** — Write a failing test that defines the expected behavior
+2. **GREEN** — Write the minimum code to make the test pass
+3. **REFACTOR** — Clean up the implementation while keeping tests green
+
+Do not skip the red step. Tests come first, implementation follows.
+
+### Specification Compliance
+
+- **SPECIFICATION.md** is the source of truth for protocol compliance
+- Target spec is **A2UI v0.9** — full compliance is the goal
+- If the spec requires it and we don't have it, it is a **gap** — not "planned", not "nice-to-have"
+- No backward compatibility with v0.8 — use v0.9 property names and message structures
+- Update SPECIFICATION.md when implementing or discovering protocol features
+
+### Server Parity
+
+The .NET server (`samples/dotnet-server`) and Python server (`samples/python-server`) must always have **identical features**. Every agent endpoint available in one must exist in the other.
+
+### Sample App Parity
+
+The Blazor WASM SPA (`samples/blazor-wasm-spa`) and Blazor Server App (`samples/blazor-server-app`) must have the **same pages and navigation links**. If a demo page is added to one, add it to the other.
+
+### Testing
+
+- All tests must pass before committing (`dotnet test`)
+- New functionality requires new tests (red-green-refactor)
+- Unit tests use **xUnit** + **bUnit** (for Blazor components)
+- Use `NullLogger<T>.Instance` when constructing services in tests
+- bUnit tests use `RenderComponent<T>()` API, not Razor syntax in `.cs` files
+
+### Build Configuration
+
+- .NET 10 is the target (migration from .NET 8 pending — do on its own branch)
+- `TreatWarningsAsErrors: true` — zero warnings policy
+- C# 12, nullable enabled, implicit usings enabled
+
+### Branching
+
+- `main` is the primary branch
+- Work on feature branches (`feature/*`) or dev branches (`dev/*`)
+- PRs to main
+
+### Commits
+
+- Commit messages should summarize the "why", not the "what"
+- Run `dotnet test` before committing
+- Do not commit unless explicitly asked
+
+### Documentation
+
+- `SPECIFICATION.md` — A2UI protocol compliance matrix (root)
+- `ROADMAP.md` — version milestones and progress (root)
+- `docs/design/` — feature design documents
+- `docs/prd/` — architecture and product requirements
+- Do not create documentation files unless explicitly asked

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1,0 +1,274 @@
+# A2UI Specification Compliance
+
+**Current Target:** [A2UI v0.9](https://github.com/google/A2UI/tree/main/specification/v0_9)
+**Current State:** Partial — v0.9 message names, mixed v0.8/v0.9 property names
+**Implementation Version:** 0.2.0-preview
+**Last Updated:** 2026-02-10
+
+This document tracks A2UI Blazor's compliance with the official A2UI protocol specification. Full compliance with the target specification is the goal.
+
+---
+
+## Specification Versions
+
+| Version | Status | Description |
+|---------|--------|-------------|
+| [v0.8](https://a2ui.org/specification/v0.8-a2ui/) | Published | Public Preview — original release |
+| [v0.9](https://github.com/google/A2UI/tree/main/specification/v0_9) | Published | Major overhaul — "Prompt First" redesign |
+| [v0.10](https://github.com/google/A2UI/tree/main/specification/v0_10) | In Development | Adds Custom Functions & Extensions (evolution guide is TBD) |
+
+### v0.8 → v0.9: Breaking Changes
+
+v0.9 was a fundamental overhaul from "Structured Output First" to "Prompt First" (optimized for LLM system prompt embedding). Key breaking changes:
+
+- **Message renames:** `beginRendering` → `createSurface`, `surfaceUpdate` → `updateComponents`, `dataModelUpdate` → `updateDataModel`
+- **Property renames:** `usageHint` → `variant`, `distribution` → `justify`, `alignment` → `align`, `minValue/maxValue` → `min/max`
+- **Component renames:** `MultipleChoice` → `ChoicePicker`
+- **Schema split:** Single schema → `common_types.json`, `server_to_client.json`, `standard_catalog.json`
+- **Data model sync:** New `sendDataModel` flag on `createSurface`
+- **Root component:** Explicit attribute → implicit "component with ID `root`"
+
+### v0.9 → v0.10: Additive Changes
+
+v0.10 evolution guide is still TBD, but new documents include:
+
+- **Custom Functions:** Developer-defined catalog extensions with JSON Schema validation
+- **Extension Specification:** Framework for extending the standard catalog
+
+---
+
+## Protocol Messages (Server → Client)
+
+| Message | Ours | v0.8 Name | v0.9 Name | v0.10 | Notes |
+|---------|------|-----------|-----------|-------|-------|
+| Create surface | ✅ | `beginRendering` | `createSurface` | same | We use v0.9 name. v0.9 adds `catalogId`, `theme` |
+| Update components | ✅ | `surfaceUpdate` | `updateComponents` | same | We use v0.9 name |
+| Update data model | ✅ | `dataModelUpdate` | `updateDataModel` | same | We use v0.9 name. v0.9 changed from array-of-pairs to JSON object |
+| Delete surface | ✅ | `deleteSurface` | `deleteSurface` | same | Unchanged across versions |
+| Render buffering | ❌ | Required | Required | TBD | **Gap** — we render immediately instead of buffering until explicit signal |
+
+**Gaps:** We do not implement render buffering, `catalogId`, or `theme` on `createSurface`.
+
+---
+
+## Client-to-Server Communication
+
+| Feature | Ours | v0.8 | v0.9 | v0.10 | Notes |
+|---------|------|------|------|-------|-------|
+| `userAction` payload | ✅ | ✅ | ✅ | same | Core action fields present |
+| A2A message envelope | ❌ | 🚨 | 🚨 | 🚨 | **Critical** — not wrapping in A2A envelope |
+| `a2uiClientCapabilities` | ❌ | 🚨 | 🚨 | 🚨 | **Required** — must declare supported catalogs |
+| `sendDataModel` sync | ❌ | N/A | ❌ | TBD | **Gap** — v0.9 requires sending data model back with actions |
+| `error` message type | ❌ | ❌ | ❌ | TBD | **Gap** — client→server error reporting |
+| Custom functions | N/A | N/A | N/A | 📋 | v0.10 feature — developer-defined extensions |
+
+**Critical Gap:** We send bare `userAction` JSON instead of wrapping it in the required A2A message envelope:
+
+```json
+// ❌ What we currently send:
+{
+  "type": "action",
+  "name": "submit",
+  "surfaceId": "main"
+}
+
+// ✅ What the spec requires:
+{
+  "metadata": {
+    "a2uiClientCapabilities": {
+      "supportedCatalogIds": ["https://a2ui.org/specification/v0_8/standard_catalog_definition.json"]
+    }
+  },
+  "message": {
+    "userAction": {
+      "name": "submit",
+      "surfaceId": "main"
+    }
+  }
+}
+```
+
+---
+
+## Component Catalog
+
+Standard components from the A2UI catalog. Property names differ between spec versions.
+
+### Display Components
+
+| Component | Ours | v0.8 | v0.9 | v0.10 | Property Gaps |
+|-----------|------|------|------|-------|---------------|
+| `Text` | ⚠️ | ✅ | ⚠️ | same | **Gap:** We use `usageHint` (v0.8), v0.9 requires `variant` |
+| `Image` | ✅ | ✅ | ✅ | same | |
+| `Icon` | ✅ | ✅ | ✅ | same | |
+| `Divider` | ✅ | ✅ | ✅ | same | |
+
+### Layout Components
+
+| Component | Ours | v0.8 | v0.9 | v0.10 | Property Gaps |
+|-----------|------|------|------|-------|---------------|
+| `Row` | ⚠️ | ✅ | ⚠️ | same | **Gap:** We use `distribution`/`alignment` (v0.8), v0.9 requires `justify`/`align` |
+| `Column` | ⚠️ | ✅ | ⚠️ | same | **Gap:** Same as Row |
+| `Card` | ✅ | ✅ | ✅ | same | |
+| `List` | ✅ | ✅ | ✅ | same | |
+| `Tabs` | ✅ | ✅ | ✅ | same | |
+| `Modal` | ⚠️ | ✅ | ⚠️ | same | **Gap:** We use `entryPointChild`/`contentChild` (v0.8), v0.9 requires `trigger`/`content` |
+
+### Input Components
+
+| Component | Ours | v0.8 | v0.9 | v0.10 | Property Gaps |
+|-----------|------|------|------|-------|---------------|
+| `Button` | ✅ | ✅ | ✅ | same | v0.9 compliant (`variant`) |
+| `TextField` | ⚠️ | ✅ | ⚠️ | same | **Gap:** v0.9 requires `value` (we use `text`), `variant` (we use `textFieldType`) |
+| `CheckBox` | ✅ | ✅ | ✅ | same | |
+| `ChoicePicker` | ⚠️ | ✅ | ⚠️ | same | **Gap:** v0.9 requires `value` (we use `selections`) |
+| `DateTimeInput` | ✅ | ✅ | ✅ | same | |
+| `Slider` | ✅ | ✅ | ✅ | same | v0.9 compliant (`min`/`max`) |
+
+### Media Components
+
+| Component | Ours | v0.8 | v0.9 | v0.10 | Property Gaps |
+|-----------|------|------|------|-------|---------------|
+| `Video` | ✅ | ✅ | ✅ | same | |
+| `AudioPlayer` | ✅ | ✅ | ✅ | same | |
+
+**Total:** 17/17 standard components implemented
+**v0.9 property compliance:** 10/17 compliant, 7 components have v0.8 property names (Text, Row, Column, Modal, TextField, ChoicePicker)
+
+---
+
+## Property Name Migration (v0.8 → v0.9)
+
+This table tracks which property names we use vs what each spec version expects.
+
+| Component | Property | Our Value | v0.9 Required | Status |
+|-----------|----------|-----------|---------------|--------|
+| `Text` | variant hint | `usageHint` | `variant` | ❌ Migrate |
+| `Row`/`Column` | horizontal distribution | `distribution` | `justify` | ❌ Migrate |
+| `Row`/`Column` | cross-axis alignment | `alignment` | `align` | ❌ Migrate |
+| `Button` | style variant | `variant` | `variant` | ✅ Compliant |
+| `Slider` | range bounds | `min`/`max` | `min`/`max` | ✅ Compliant |
+| `Tabs` | tab list | `tabs` | `tabs` | ✅ Compliant |
+| `Modal` | child slots | `entryPointChild`/`contentChild` | `trigger`/`content` | ❌ Migrate |
+| `TextField` | text value | `text` | `value` | ❌ Migrate |
+| `TextField` | field type | `textFieldType` | `variant` | ❌ Migrate |
+| `ChoicePicker` | selections | `selections` | `value` | ❌ Migrate |
+
+---
+
+## Data Binding
+
+| Feature | Ours | v0.8 | v0.9 | v0.10 | Notes |
+|---------|------|------|------|-------|-------|
+| Literal values | ✅ | ✅ | ✅ | same | |
+| Path-based binding | ✅ | ✅ | ✅ | same | JSON Pointer (RFC 6901) |
+| Combined literal + path | ✅ | ✅ | ✅ | same | |
+| List iteration | ✅ | ✅ | ✅ | same | |
+| `formatString` interpolation | ❌ | N/A | ❌ | same | **Gap** — v0.9 requires `${expression}` syntax |
+
+---
+
+## Protocol Features
+
+| Feature | Ours | v0.8 | v0.9 | v0.10 | Notes |
+|---------|------|------|------|-------|-------|
+| JSONL stream parsing | ✅ | ✅ | ✅ | same | |
+| SSE transport | ✅ | ✅ | ✅ | same | |
+| Surface state management | ✅ | ✅ | ✅ | same | |
+| Component tree rendering | ✅ | ✅ | ✅ | same | |
+| Dynamic component registry | ✅ | ✅ | ✅ | same | |
+| Action context resolution | ✅ | ✅ | ✅ | same | |
+| Catalog ID in `createSurface` | ❌ | N/A | ❌ | same | **Gap** — v0.9 requires parsing `catalogId` |
+| Theme support | ❌ | N/A | ❌ | same | **Gap** — v0.9 requires `primaryColor` etc. |
+| Custom functions | N/A | N/A | N/A | 📋 | v0.10 feature |
+| Extension catalogs | N/A | N/A | N/A | 📋 | v0.10 feature |
+
+---
+
+## Known Gaps & Roadmap
+
+### High Priority (Blocking spec compliance)
+
+1. **A2A Message Envelope** (🚨 Critical — all versions)
+   - Wrap `userAction` in A2A message structure
+   - Add `metadata.a2uiClientCapabilities`
+   - Declare supported catalog IDs
+
+2. **Property Name Migration to v0.9** (🚨 7 components non-compliant)
+   - Migrate all property names to v0.9: `usageHint` → `variant`, `distribution` → `justify`, `alignment` → `align`, `entryPointChild`/`contentChild` → `trigger`/`content`, `text` → `value`, `textFieldType` → `variant`, `selections` → `value`
+   - Affects: Text, Row, Column, Modal, TextField, ChoicePicker
+
+3. **Render Buffering** (🚨 Required — all versions)
+   - Buffer messages until explicit render signal
+   - Currently rendering immediately on `createSurface`
+
+### Medium Priority (v0.9 gaps)
+
+4. **`formatString` Interpolation** (❌ v0.9 gap)
+   - Support `${expression}` syntax in bound values
+
+5. **`sendDataModel` Sync** (❌ v0.9 gap)
+   - Echo data model in client→server messages when `sendDataModel: true`
+
+6. **Catalog & Theme Support** (❌ v0.9 gap)
+   - Parse `catalogId` from `createSurface`
+   - Parse and apply `theme` properties
+
+### Low Priority (v0.10 / Future)
+
+7. **Custom Functions** (📋 v0.10 feature)
+   - Developer-defined catalog extensions
+   - JSON Schema validation for function calls
+
+8. **Extension Specification** (📋 v0.10 feature)
+   - Framework for extending the standard catalog
+
+9. **Error Reporting to Server** (❌ v0.9 gap)
+   - Send client-side errors to server via `error` message type
+
+---
+
+## Testing Against Reference Implementations
+
+| Test | Status | Notes |
+|------|--------|-------|
+| Python sample server | ✅ | All 4 demos working |
+| .NET sample server | ✅ | All 4 demos working |
+| Official A2UI reference agents | ❓ | Not tested |
+| v0.9 strict-mode server | ❓ | Not tested — property name mismatches may break |
+
+---
+
+## Contributing
+
+When implementing new protocol features:
+
+1. Update this document first (mark as 📋 Planned)
+2. Implement the feature
+3. Add tests covering the spec requirements
+4. Update status to ✅ Implemented
+5. Document any deviations in the "Notes" column
+
+---
+
+## References
+
+- [A2UI v0.8 Specification](https://a2ui.org/specification/v0.8-a2ui/)
+- [A2UI v0.9 Specification](https://github.com/google/A2UI/tree/main/specification/v0_9)
+- [A2UI v0.10 Specification](https://github.com/google/A2UI/tree/main/specification/v0_10) (in development)
+- [A2UI v0.9 Evolution Guide](https://github.com/google/A2UI/blob/main/specification/v0_9/docs/evolution_guide.md)
+- [A2UI GitHub Repository](https://github.com/google/A2UI)
+- [Renderer Development Guide](https://a2ui.org/guides/renderer-development/)
+
+---
+
+**Legend:**
+| Symbol | Meaning |
+|--------|---------|
+| ✅ | Implemented and tested |
+| ⚠️ | Partially implemented (property name mismatch) |
+| ❌ | Not implemented |
+| 🚨 | Critical gap (required by spec) |
+| 📋 | Planned or not yet required |
+| ❓ | Unknown or untested |
+| N/A | Not applicable for this version |


### PR DESCRIPTION
## Summary
- **SPECIFICATION.md**: A2UI v0.9 compliance matrix tracking all protocol gaps
- **CLAUDE.md**: Project conventions (red-green-refactor, parity rules, spec compliance)
- **Issue template**: `spec-compliance.md` for tracking spec gaps

## Context
Audit of A2UI specification compliance revealed we target v0.9 but have a mixed v0.8/v0.9 implementation. This PR establishes the tracking infrastructure before we start closing gaps.

## Key findings documented
- 17/17 components implemented, but 7 have v0.8 property names
- A2A message envelope not implemented (critical)
- Render buffering not implemented (required)
- Several v0.9 features missing (formatString, sendDataModel, themes)

## Test plan
- [ ] No code changes — documentation and templates only
- [ ] Verify SPECIFICATION.md renders correctly on GitHub
- [ ] Verify issue template appears in GitHub issue creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)